### PR TITLE
Add missing color definitions to examples/bigtest.

### DIFF
--- a/examples/bigtest/bigtest.ino
+++ b/examples/bigtest/bigtest.ino
@@ -2,6 +2,16 @@
 #include <Adafruit_GFX.h>
 #include <TFT_ILI9163C.h>
 
+// Color definitions
+#define BLACK   0x0000
+#define BLUE    0x001F
+#define RED     0xF800
+#define GREEN   0x07E0
+#define CYAN    0x07FF
+#define MAGENTA 0xF81F
+#define YELLOW  0xFFE0  
+#define WHITE   0xFFFF
+
 /*
 Teensy3.x and Arduino's
 You are using 4 wire SPI here, so:


### PR DESCRIPTION
Without, the bigtest example does not compile.

Your driver works great on an Arduino ProMini. Thanks!
