### PR TITLE
A few minor fixes plus a compile on arduino fix

### DIFF
--- a/TFT_ILI9163C.h
+++ b/TFT_ILI9163C.h
@@ -348,10 +348,10 @@ class TFT_ILI9163C : public Print {
 		__attribute__((always_inline)) { spiwrite(c >> 8); spiwrite(c); }
 
 		void enableCommandStream(void)
-		__attribute__((always_inline)) { *rsport &= ~dcpinmask;//low }
+		__attribute__((always_inline)) { *rsport &= ~dcpinmask;/*low*/ }
 
 		void enableDataStream(void)
-		__attribute__((always_inline)) { *rsport |= dcpinmask;//hi }
+		__attribute__((always_inline)) { *rsport |= dcpinmask;/*hi*/ }
 
 		void startTransaction(void)
 		__attribute__((always_inline)) {
@@ -369,7 +369,7 @@ class TFT_ILI9163C : public Print {
 		}
 
 		void disableCS(void)
-		__attribute__((always_inline)) { *csport |= cspinmask;//hi }
+		__attribute__((always_inline)) { *csport |= cspinmask;/*hi*/ }
 /* -----------------------------  ARM (DUE)  -------------------------------*/
 	#elif defined(__SAM3X8E__)
 		Pio 				*dataport, *clkport, *csport, *rsport;
@@ -383,10 +383,10 @@ class TFT_ILI9163C : public Print {
 		__attribute__((always_inline)) { SPI.transfer16(c); }
 
 		void enableCommandStream(void)
-		__attribute__((always_inline)) { rsport->PIO_CODR |=  dcpinmask;//LO }
+		__attribute__((always_inline)) { rsport->PIO_CODR |=  dcpinmask;/*LO*/ }
 
 		void enableDataStream(void)
-		__attribute__((always_inline)) { rsport->PIO_SODR |=  dcpinmask;//HI }
+		__attribute__((always_inline)) { rsport->PIO_SODR |=  dcpinmask;/*HI*/ }
 
 		void startTransaction(void)
 		__attribute__((always_inline)) {
@@ -404,7 +404,7 @@ class TFT_ILI9163C : public Print {
 		}
 
 		void disableCS(void)
-		__attribute__((always_inline)) { csport->PIO_SODR |=  cspinmask;//HI }
+		__attribute__((always_inline)) { csport->PIO_SODR |=  cspinmask;/*HI*/ }
 
 /* --------------------------- ARM (Teensy LC) ------------------------*/
 	#elif defined(__MKL26Z64__)

--- a/examples/bigtest/bigtest.ino
+++ b/examples/bigtest/bigtest.ino
@@ -72,20 +72,6 @@ void testlines(uint16_t color) {
 	delay(500);
 }
 
-
-void testdrawtext(char *text, uint16_t color) {
-	tft.setTextScale(1);
-	tft.setTextColor(WHITE);
-	tft.setCursor(0, 0);
-
-	for (uint8_t i = 0; i < 168; i++) {
-		if (i == '\n') continue;
-		tft.write(i);
-		if ((i > 0) && (i % 21 == 0))
-			tft.println();
-	}
-}
-
 void testfastlines(uint16_t color1, uint16_t color2) {
 	tft.clearScreen();
 	for (int16_t y = 0; y < tft.height() - 1; y += 5) {

--- a/examples/bigtest/bigtest.ino
+++ b/examples/bigtest/bigtest.ino
@@ -146,7 +146,7 @@ void testtriangles() {
 
 void testroundrects() {
 	tft.clearScreen();
-	int color = 100;
+	unsigned int color = 100;
 	int i;
 	int t;
 	for (t = 0; t <= 4; t += 1) {

--- a/examples/bigtest/bigtest.ino
+++ b/examples/bigtest/bigtest.ino
@@ -191,7 +191,7 @@ void randomRect(bool fill) {
 	uint8_t k, c;
 	for (k = 0; k < 16; k++) {
 		for (c = 0; c < 32; c++) {
-			uint8_t cx, cy, x, y, w, h;
+			int8_t cx, cy, x, y, w, h;
 			//  center
 			cx = random(0, tft.width());
 			cy = random(0, tft.height());


### PR DESCRIPTION
The first change is rewrite of #47 opened on 22 Jul 2016 by alf-ytakada but less intrusive (changed '//hi }' to '/*hi*/ }'
Fix signed int overflow undefined behaviour I guess only affects C++11 and newer (-Wall -Wextra -std=gnu++11)
Removed unused function 'testdrawtext' from bigtest.cpp
And the last commit is uint/int fix.