### PR TITLE
Fix Rotation errors, make colorSpace public

### DIFF
--- a/TFT_ILI9163C.cpp
+++ b/TFT_ILI9163C.cpp
@@ -588,7 +588,7 @@ void TFT_ILI9163C::chipInit() {
 		delay(1);
   
 		writecommand(CMD_CLMADRS);//Set Column Address  
-		writedata16(0x00); 
+		writedata16(0x00);
 		writedata16(_GRAMWIDTH); 
   
 		writecommand(CMD_PGEADRS);//Set Page Address  
@@ -623,6 +623,7 @@ void TFT_ILI9163C::colorSpace(uint8_t cspace) {
 	} else {
 		bitSet(_Mactrl_Data,3);
 	}
+	_colorspaceData = cspace;
 }
 
 void TFT_ILI9163C::invertDisplay(boolean i) {

--- a/TFT_ILI9163C.cpp
+++ b/TFT_ILI9163C.cpp
@@ -748,7 +748,8 @@ void TFT_ILI9163C::clearScreen(uint16_t color) {
 		writecommand_last(CMD_NOP);
 		SPI.endTransaction();
 	#else
-		setAddr(0x00,0x00,_GRAMWIDTH,_GRAMHEIGH);//go home
+		if (rotation % 2) setAddr(0x00,0x00,_GRAMHEIGH,_GRAMWIDTH);//go home
+		else              setAddr(0x00,0x00,_GRAMWIDTH,_GRAMHEIGH);//go home
 		for (px = 0;px < _GRAMSIZE; px++){
 			writedata16(color);
 		}
@@ -808,7 +809,8 @@ void TFT_ILI9163C::writeScreen24(const uint32_t *bitmap,uint16_t size) {
 }
 
 void TFT_ILI9163C::homeAddress() {
-	setAddrWindow(0x00,0x00,_GRAMWIDTH,_GRAMHEIGH);
+	if (rotation % 2) setAddr(0x00,0x00,_GRAMHEIGH,_GRAMWIDTH);//go home
+	else              setAddr(0x00,0x00,_GRAMWIDTH,_GRAMHEIGH);//go home
 }
 
 
@@ -1093,8 +1095,8 @@ void TFT_ILI9163C::setRotation(uint8_t m) {
 		break;
 	case 3:
 		_Mactrl_Data = 0b10101000;
-		_width  = _TFTWIDTH;
-		_height = _TFTHEIGHT;//-__OFFSET;
+		_width  = _TFTHEIGHT;
+		_height = _TFTWIDTH;//-__OFFSET;
 		break;
 	}
 	colorSpace(_colorspaceData);

--- a/TFT_ILI9163C.h
+++ b/TFT_ILI9163C.h
@@ -179,6 +179,7 @@ class TFT_ILI9163C : public Adafruit_GFX {
   //convert 24bit color into packet 16 bit one (credits for this are all mine)
 	inline uint16_t Color24To565(int32_t color_) { return ((((color_ >> 16) & 0xFF) / 8) << 11) | ((((color_ >> 8) & 0xFF) / 4) << 5) | (((color_) &  0xFF) / 8);}
 	void 		setBitrate(uint32_t n);	
+	void 		colorSpace(uint8_t cspace);
  protected:
 	volatile uint8_t		_Mactrl_Data;//container for the memory access control data
 	uint8_t					_colorspaceData;
@@ -407,7 +408,6 @@ class TFT_ILI9163C : public Adafruit_GFX {
 		void		writedata16(uint16_t d);
 	#endif
  private:
-	void 		colorSpace(uint8_t cspace);
 	void 		setAddr(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
 	uint8_t		sleep;
 	void 		chipInit();

--- a/_settings/TFT_ILI9163C_settings.h
+++ b/_settings/TFT_ILI9163C_settings.h
@@ -4,7 +4,7 @@
 
 //DID YOU HAVE A RED PCB, BLACk PCB or WHAT DISPLAY TYPE???????????? 
 //  ---> SELECT HERE <----
-#define __144_RED_PCB__//128x128
+//#define __144_RED_PCB__//128x128
 //#define __144_BLACK_PCB__//128x128
 //#define __22_RED_PCB__//240x320
 //---------------------------------------

--- a/_settings/TFT_ILI9163C_settings.h
+++ b/_settings/TFT_ILI9163C_settings.h
@@ -57,7 +57,7 @@ Not tested!
 #else
 	#define _TFTWIDTH  		128//128
 	#define _TFTHEIGHT 		160//160
-	#define _GRAMWIDTH      128
+	#define _GRAMWIDTH      127
 	#define _GRAMHEIGH      160
 	#define _GRAMSIZE		_GRAMWIDTH * _GRAMHEIGH
 	#define __COLORSPC		1// 1:GBR - 0:RGB

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TFT_ILI9163C
-version=0.9a
+version=0.9-a
 author=Max MC Costa
 maintainer=sumotoy <sumotoy@gmail.com>
 sentence=A fast SPI driver for TFT drived by ILI9163C, fully SPI Transaction compatible and very fast with Teensy 3

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=TFT_ILI9163C
-version=0.9
+version=0.9a
 author=Max MC Costa
 maintainer=sumotoy <sumotoy@gmail.com>
 sentence=A fast SPI driver for TFT drived by ILI9163C, fully SPI Transaction compatible and very fast with Teensy 3
 paragraph=This library works with many MCU's included Arduino's but it's particular fast with Teensy 3, Teensy 3.1.
 category=Display
-url=https://github.com/sumotoy/TFT_ILI9163C
+url=https://github.com/ArduinoHannover/TFT_ILI9163C
 architectures=*


### PR DESCRIPTION
colorSpace public:
Case: Let the user decide without change of the code (pre flashed) what
display they have and save to EEPROM.
Rotation errors:
Height and Width were not altered for clearScreen